### PR TITLE
Added functional full representation from standard batterymonitor plasmoid

### DIFF
--- a/contents/ui/BadgeOverlay.qml
+++ b/contents/ui/BadgeOverlay.qml
@@ -1,0 +1,58 @@
+/***************************************************************************
+ *   Copyright (C) 2016 Kai Uwe Broulik <kde@privat.broulik.de>            *
+ *   Copyright (C) 2016 Marco Martin <mart@kde.org>                            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
+ ***************************************************************************/
+
+import QtQuick 2.4
+import QtGraphicalEffects 1.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as PlasmaComponents
+
+Item {
+    property alias text: label.text
+    property Item icon
+
+    Rectangle {
+        id: badgeRect
+        anchors {
+            right: parent.right
+            bottom: parent.bottom
+        }
+        color: PlasmaCore.ColorScope.backgroundColor
+        width: Math.max(units.gridUnit, label.width + units.devicePixelRatio * 2)
+        height: label.height
+        radius: units.devicePixelRatio * 3
+        opacity: 0.9
+    }
+
+    PlasmaComponents.Label {
+        id: label
+        anchors.centerIn: badgeRect
+        height: paintedHeight
+        font.pixelSize: Math.max(icon.height/4, theme.smallestFont.pixelSize*0.8)
+    }
+
+    layer.enabled: true
+    layer.effect: DropShadow {
+        horizontalOffset: 0
+        verticalOffset: 0
+        radius: units.devicePixelRatio * 2
+        samples: radius*2
+        color: Qt.rgba(0, 0, 0, 0.5)
+    }
+}

--- a/contents/ui/BatteryItem.qml
+++ b/contents/ui/BatteryItem.qml
@@ -1,0 +1,217 @@
+/*
+ *   Copyright 2012-2013 Daniel Nicoletti <dantti12@gmail.com>
+ *   Copyright 2013-2015 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2 or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import QtQuick.Layouts 1.1
+
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as PlasmaComponents
+import org.kde.plasma.extras 2.0 as PlasmaExtras
+import org.kde.plasma.workspace.components 2.0
+import org.kde.kcoreaddons 1.0 as KCoreAddons
+import "logic.js" as Logic
+
+Item {
+    id: batteryItem
+    height: childrenRect.height
+
+    property var battery
+
+    // NOTE: According to the UPower spec this property is only valid for primary batteries, however
+    // UPower seems to set the Present property false when a device is added but not probed yet
+    readonly property bool isPresent: model["Plugged in"]
+
+    readonly property bool isBroken: model.Capacity > 0 && model.Capacity < 50
+
+    property Component batteryDetails: Flow { // GridLayout crashes with a Repeater in it somehow
+        id: detailsLayout
+
+        property int leftColumnWidth: 0
+        width: units.gridUnit * 11
+
+        PlasmaComponents.Label {
+            id: brokenBatteryLabel
+            width: parent ? parent.width : implicitWidth
+            wrapMode: Text.WordWrap
+            text: batteryItem.isBroken && typeof model.Capacity !== "undefined" ? i18n("The capacity of this battery is %1%. This means it is broken and needs a replacement. Please contact your hardware vendor for more details.", model.Capacity) : ""
+            font.pointSize: !!detailsLayout.parent.inListView ? theme.smallestFont.pointSize : theme.defaultFont.pointSize
+            visible: batteryItem.isBroken
+        }
+
+        Repeater {
+            id: detailsRepeater
+
+            model: Logic.batteryDetails(batteryItem.battery, batterywidget.remainingTime)
+
+            PlasmaComponents.Label {
+                id: detailsLabel
+                width: modelData.value && parent ? parent.width - detailsLayout.leftColumnWidth - units.smallSpacing : detailsLayout.leftColumnWidth + units.smallSpacing
+                wrapMode: Text.NoWrap
+                onPaintedWidthChanged: { // horrible HACK to get a column layout
+                    if (paintedWidth > detailsLayout.leftColumnWidth) {
+                        detailsLayout.leftColumnWidth = paintedWidth
+                    }
+                }
+                height: implicitHeight
+                text: modelData.value ? modelData.value : modelData.label
+
+                states: [
+                    State {
+                        when: !!detailsLayout.parent.inListView // HACK
+                        PropertyChanges {
+                            target: detailsLabel
+                            horizontalAlignment: modelData.value ? Text.AlignRight : Text.AlignLeft
+                            font.pointSize: theme.smallestFont.pointSize
+                            width: parent ? parent.width / 2 : 0
+                            elide: Text.ElideNone // eliding and height: implicitHeight causes loops
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+    Column {
+        width: parent.width
+        spacing: 0
+
+        PlasmaCore.ToolTipArea {
+            width: parent.width
+            height: infoRow.height
+            active: !detailsLoader.active
+            z: 2
+
+            mainItem: Row {
+                id: batteryItemToolTip
+
+                property int _s: units.largeSpacing / 2
+
+                Layout.minimumWidth: implicitWidth + batteryItemToolTip._s
+                Layout.minimumHeight: implicitHeight + batteryItemToolTip._s * 2
+                Layout.maximumWidth: implicitWidth + batteryItemToolTip._s
+                Layout.maximumHeight: implicitHeight + batteryItemToolTip._s * 2
+                width: implicitWidth + batteryItemToolTip._s
+                height: implicitHeight + batteryItemToolTip._s * 2
+
+                spacing: batteryItemToolTip._s*2
+
+                BatteryIcon {
+                    x: batteryItemToolTip._s * 2
+                    y: batteryItemToolTip._s
+                    width: units.iconSizes.desktop // looks weird and small but that's what DefaultTooltip uses
+                    height: width
+                    batteryType: batteryIcon.batteryType
+                    percent: batteryIcon.percent
+                    hasBattery: batteryIcon.hasBattery
+                    pluggedIn: batteryIcon.pluggedIn
+                    visible: !batteryItem.isBroken
+                }
+
+                Column {
+                    id: mainColumn
+                    x: batteryItemToolTip._s
+                    y: batteryItemToolTip._s
+
+                    PlasmaExtras.Heading {
+                        level: 3
+                        text: batteryNameLabel.text
+                    }
+                    Loader {
+                        sourceComponent: batteryItem.batteryDetails
+                        opacity: 0.5
+                    }
+                }
+            }
+
+            RowLayout {
+                id: infoRow
+                width: parent.width
+                spacing: units.gridUnit
+
+                BatteryIcon {
+                    id: batteryIcon
+                    Layout.alignment: Qt.AlignTop
+                    width: units.iconSizes.medium
+                    height: width
+                    batteryType: model.Type
+                    percent: model.Percent
+                    hasBattery: batteryItem.isPresent
+                    pluggedIn: model.State === "Charging" && model["Is Power Supply"]
+                }
+
+                Column {
+                    Layout.fillWidth: true
+                    Layout.alignment: batteryItem.isPresent ? Qt.AlignTop : Qt.AlignVCenter
+
+                    RowLayout {
+                        width: parent.width
+                        spacing: units.smallSpacing
+
+                        PlasmaComponents.Label {
+                            id: batteryNameLabel
+                            Layout.fillWidth: true
+                            height: implicitHeight
+                            elide: Text.ElideRight
+                            text: model["Pretty Name"]
+                        }
+
+                        PlasmaComponents.Label {
+                            text: Logic.stringForBatteryState(model)
+                            height: implicitHeight
+                            visible: model["Is Power Supply"]
+                            opacity: 0.6
+                        }
+
+                        PlasmaComponents.Label {
+                            id: batteryPercent
+                            height: paintedHeight
+                            horizontalAlignment: Text.AlignRight
+                            visible: batteryItem.isPresent
+                            text: i18nc("Placeholder is battery percentage", "%1%", model.Percent)
+                        }
+                    }
+
+                    PlasmaComponents.ProgressBar {
+                        width: parent.width
+                        minimumValue: 0
+                        maximumValue: 100
+                        visible: batteryItem.isPresent
+                        value: Number(model.Percent)
+                    }
+                }
+            }
+        }
+
+        Loader {
+            id: detailsLoader
+            property bool inListView: true
+            anchors {
+                left: parent.left
+                leftMargin: batteryIcon.width + units.gridUnit
+                right: parent.right
+            }
+            visible: !!item
+            opacity: 0.5
+            sourceComponent: batteryDetails
+            active: batterywidget.batteries.count < 2
+        }
+    }
+
+}

--- a/contents/ui/BrightnessItem.qml
+++ b/contents/ui/BrightnessItem.qml
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2012-2013 Daniel Nicoletti <dantti12@gmail.com>
+ *   Copyright 2013, 2015 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2 or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import QtQuick.Layouts 1.1
+
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as Components
+
+RowLayout {
+    property alias icon: brightnessIcon.source
+    property alias label: brightnessLabel.text
+    property alias value: brightnessSlider.value
+    property alias maximumValue: brightnessSlider.maximumValue
+
+    spacing: units.gridUnit
+
+    PlasmaCore.IconItem {
+        id: brightnessIcon
+        Layout.alignment: Qt.AlignTop
+        Layout.preferredWidth: units.iconSizes.medium
+        Layout.preferredHeight: width
+    }
+
+    Column {
+        id: brightnessColumn
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignTop
+        spacing: 0
+
+        Components.Label {
+            id: brightnessLabel
+            width: parent.width
+            height: paintedHeight
+        }
+
+        Components.Slider {
+            id: brightnessSlider
+            width: parent.width
+            // Don't allow the slider to turn off the screen
+            // Please see https://git.reviewboard.kde.org/r/122505/ for more information
+            minimumValue: maximumValue > 100 ? 1 : 0
+            stepSize: 1
+        }
+    }
+}

--- a/contents/ui/InhibitionHint.qml
+++ b/contents/ui/InhibitionHint.qml
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2015 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2 or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import QtQuick.Layouts 1.1
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as Components
+
+RowLayout {
+    property alias iconSource: iconItem.source
+    property alias text: label.text
+
+    spacing: units.smallSpacing
+
+    PlasmaCore.IconItem {
+        id: iconItem
+        Layout.preferredWidth: units.iconSizes.medium
+        Layout.preferredHeight: units.iconSizes.medium
+        visible: valid
+    }
+
+    Components.Label {
+        id: label
+        Layout.fillWidth: true
+        height: implicitHeight
+        font.pointSize: theme.smallestFont.pointSize
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
+        maximumLineCount: 3
+    }
+}

--- a/contents/ui/PopupDialog.qml
+++ b/contents/ui/PopupDialog.qml
@@ -1,0 +1,138 @@
+/*
+ *   Copyright 2011 Viranch Mehta <viranch.mehta@gmail.com>
+ *   Copyright 2013-2016 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2 or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as Components
+import org.kde.plasma.extras 2.0 as PlasmaExtras
+import org.kde.kquickcontrolsaddons 2.0
+
+FocusScope {
+    id: dialog
+    focus: true
+
+    property alias model: batteryList.model
+    property bool pluggedIn
+
+    property int remainingTime
+
+    property bool isBrightnessAvailable
+    property bool isKeyboardBrightnessAvailable
+
+    signal powermanagementChanged(bool checked)
+
+    Component.onCompleted: {
+        // setup handler on slider value manually to avoid change on creation
+
+        brightnessSlider.valueChanged.connect(function() {
+            batterywidget.screenBrightness = brightnessSlider.value
+        })
+
+        keyboardBrightnessSlider.valueChanged.connect(function() {
+            batterywidget.keyboardBrightness = keyboardBrightnessSlider.value
+        })
+    }
+
+    Column {
+        id: settingsColumn
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: parent.width - units.gridUnit
+        spacing: Math.round(units.gridUnit / 2)
+
+        Components.Label {
+            // this is just for metrics, TODO use TextMetrics in 5.4 instead
+            id: percentageMeasurementLabel
+            text: i18nc("Used for measurement", "100%")
+            visible: false
+        }
+
+        PowerManagementItem {
+            id: pmSwitch
+            width: parent.width
+            onEnabledChanged: powermanagementChanged(enabled)
+            KeyNavigation.tab: batteryList
+            KeyNavigation.backtab: keyboardBrightnessSlider
+        }
+
+        BrightnessItem {
+            id: brightnessSlider
+            width: parent.width
+
+            icon: "video-display-brightness"
+            label: i18n("Display Brightness")
+            visible: isBrightnessAvailable
+            value: batterywidget.screenBrightness
+            maximumValue: batterywidget.maximumScreenBrightness
+            KeyNavigation.tab: keyboardBrightnessSlider
+            KeyNavigation.backtab: batteryList
+
+            // Manually dragging the slider around breaks the binding
+            Connections {
+                target: batterywidget
+                onScreenBrightnessChanged: brightnessSlider.value = batterywidget.screenBrightness
+            }
+        }
+
+        BrightnessItem {
+            id: keyboardBrightnessSlider
+            width: parent.width
+
+            icon: "input-keyboard-brightness"
+            label: i18n("Keyboard Brightness")
+            value: batterywidget.keyboardBrightness
+            maximumValue: batterywidget.maximumKeyboardBrightness
+            visible: isKeyboardBrightnessAvailable
+            KeyNavigation.tab: pmSwitch
+            KeyNavigation.backtab: brightnessSlider
+
+            // Manually dragging the slider around breaks the binding
+            Connections {
+                target: batterywidget
+                onKeyboardBrightnessChanged: keyboardBrightnessSlider.value = batterywidget.keyboardBrightness
+            }
+        }
+    }
+
+    PlasmaExtras.ScrollArea {
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            top: settingsColumn.bottom
+            topMargin: units.gridUnit // not divided by 2 for unified looks
+            bottom: dialog.bottom
+        }
+        width: parent.width - units.gridUnit
+
+        ListView {
+            id: batteryList
+
+            boundsBehavior: Flickable.StopAtBounds
+            spacing: Math.round(units.gridUnit / 2)
+
+            KeyNavigation.tab: brightnessSlider
+            KeyNavigation.backtab: pmSwitch
+
+            delegate: BatteryItem {
+                width: parent.width
+                battery: model
+            }
+        }
+    }
+
+}

--- a/contents/ui/PowerManagementItem.qml
+++ b/contents/ui/PowerManagementItem.qml
@@ -1,0 +1,123 @@
+/*
+ *   Copyright 2012-2013 Daniel Nicoletti <dantti12@gmail.com>
+ *   Copyright 2013, 2015 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2 or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import QtQuick.Layouts 1.1
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as Components
+import org.kde.kquickcontrolsaddons 2.0
+
+Column {
+    property alias enabled: pmCheckBox.checked
+
+    spacing: 0
+
+    RowLayout {
+        width: parent.width
+        spacing: units.gridUnit
+
+        MouseArea {
+            Layout.fillWidth: true
+            height: childrenRect.height
+            onClicked: {
+                pmCheckBox.forceActiveFocus()
+                pmCheckBox.checked = !pmCheckBox.checked
+            }
+
+            PlasmaCore.ToolTipArea {
+                anchors.fill: parent
+                subText: i18n("Disabling power management will prevent your screen and computer from turning off automatically.\n\nMost applications will automatically suppress power management when they don't want to have you interrupted.")
+            }
+
+            RowLayout {
+                width: parent.width
+                spacing: units.gridUnit
+
+                Item {
+                    width: units.iconSizes.medium
+                    height: width
+
+                    Components.CheckBox {
+                        id: pmCheckBox
+                        anchors.centerIn: parent
+                        checked: true
+                        // we don't want to mess with the checked state but still reflect that changing it might not yield the desired result
+                        opacity: inhibitions.length > 0 ? 0.5 : 1
+                        Behavior on opacity {
+                            NumberAnimation { duration: units.longDuration }
+                        }
+                    }
+                }
+
+                Components.Label {
+                    Layout.fillWidth: true
+                    text: i18n("Enable Power Management")
+                }
+            }
+        }
+
+        Components.ToolButton {
+            iconSource: "configure"
+            onClicked: batterywidget.action_powerdevilkcm()
+            tooltip: i18n("Configure Power Saving...")
+            visible: batterywidget.kcmsAuthorized
+        }
+    }
+
+    Column {
+        anchors {
+            left: parent.left
+            leftMargin: units.iconSizes.medium + units.gridUnit
+            right: parent.right
+        }
+        spacing: units.smallSpacing
+
+        InhibitionHint {
+            width: parent.width
+            visible: pmSource.data["PowerDevil"] && pmSource.data["PowerDevil"]["Is Lid Present"] && !pmSource.data["PowerDevil"]["Triggers Lid Action"] ? true : false
+            iconSource: "computer-laptop"
+            text: i18n("Your notebook is configured not to suspend when closing the lid while an external monitor is connected.")
+        }
+
+        InhibitionHint {
+            width: parent.width
+            visible: inhibitions.length > 0
+            iconSource: inhibitions.length > 0 ? inhibitions[0].Icon || "" : ""
+            text: {
+                if (inhibitions.length > 1) {
+                    return i18ncp("Some Application and n others are currently suppressing PM",
+                                  "%2 and %1 other application are currently suppressing power management.",
+                                  "%2 and %1 other applications are currently suppressing power management.",
+                                  inhibitions.length - 1, inhibitions[0].Name) // plural only works on %1
+                } else if (inhibitions.length === 1) {
+                    if (!inhibitions[0].Reason) {
+                        return i18nc("Some Application is suppressing PM",
+                                     "%1 is currently suppressing power management.", inhibitions[0].Name)
+                    } else {
+                        return i18nc("Some Application is suppressing PM: Reason provided by the app",
+                                     "%1 is currently suppressing power management: %2", inhibitions[0].Name, inhibitions[0].Reason)
+                    }
+                } else {
+                    return ""
+                }
+            }
+        }
+    }
+}

--- a/contents/ui/logic.js
+++ b/contents/ui/logic.js
@@ -1,0 +1,96 @@
+/*
+ *   Copyright 2011 Sebastian Kügler <sebas@kde.org>
+ *   Copyright 2012 Viranch Mehta <viranch.mehta@gmail.com>
+ *   Copyright 2014-2016 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2 or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+function stringForBatteryState(batteryData) {
+    if (batteryData["Plugged in"]) {
+        switch(batteryData["State"]) {
+            case "Discharging": return i18n("Discharging");
+            case "FullyCharged": return i18n("Fully Charged");
+            case "Charging": return i18n("Charging");
+            // when in doubt we're not charging
+            default: return i18n("Not Charging");
+        }
+    } else {
+        return i18nc("Battery is currently not present in the bay","Not present");
+    }
+}
+
+function batteryDetails(batteryData, remainingTime) {
+    var data = []
+
+    if (remainingTime > 0 && batteryData["Is Power Supply"] && (batteryData["State"] == "Discharging" || batteryData["State"] == "Charging")) {
+        data.push({label: (batteryData["State"] == "Charging" ? i18n("Time To Full:") : i18n("Time To Empty:")) })
+        data.push({value: KCoreAddons.Format.formatDuration(remainingTime, KCoreAddons.FormatTypes.HideSeconds) })
+    }
+
+    if (batteryData["Is Power Supply"] && batteryData["Capacity"] != "" && typeof batteryData["Capacity"] == "number") {
+        data.push({label: i18n("Capacity:") })
+        data.push({value: i18nc("Placeholder is battery capacity", "%1%", batteryData["Capacity"]) })
+    }
+
+    // Non-powersupply batteries have a name consisting of the vendor and model already
+    if (batteryData["Is Power Supply"]) {
+        if (batteryData["Vendor"] != "" && typeof batteryData["Vendor"] == "string") {
+            data.push({label: i18n("Vendor:") })
+            data.push({value: batteryData["Vendor"] })
+        }
+
+        if (batteryData["Product"] != "" && typeof batteryData["Product"] == "string") {
+            data.push({label: i18n("Model:") })
+            data.push({value: batteryData["Product"] })
+        }
+    }
+
+    return data
+}
+
+function updateBrightness(rootItem, source) {
+    if (!source.data["PowerDevil"]) {
+        return;
+    }
+
+    // we don't want passive brightness change send setBrightness call
+    rootItem.disableBrightnessUpdate = true;
+
+    if (typeof source.data["PowerDevil"]["Screen Brightness"] === 'number') {
+        rootItem.screenBrightness = source.data["PowerDevil"]["Screen Brightness"];
+    }
+    if (typeof source.data["PowerDevil"]["Keyboard Brightness"] === 'number') {
+        rootItem.keyboardBrightness = source.data["PowerDevil"]["Keyboard Brightness"];
+    }
+    rootItem.disableBrightnessUpdate = false;
+}
+
+function updateInhibitions(rootItem, source) {
+    var inhibitions = [];
+
+    if (source.data["Inhibitions"]) {
+        for(var key in pmSource.data["Inhibitions"]) {
+            if (key === "plasmashell" || key === "plasmoidviewer") { // ignore our own inhibition
+                continue
+            }
+
+            inhibitions.push(pmSource.data["Inhibitions"][key])
+        }
+    }
+
+    rootItem.inhibitions = inhibitions
+}

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -5,36 +5,156 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 2.0 as PlasmaComponent
 import org.kde.kcoreaddons 1.0 as KCoreAddons
 
+import org.kde.kquickcontrolsaddons 2.0
+import "logic.js" as Logic
+
 Item {
-	id: widget
+	id: batterywidget
 
 	AppletConfig { id: config }
 
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/powermanagement/powermanagementengine.h
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/powermanagement/powermanagementengine.cpp
-	PlasmaCore.DataSource {
-		id: pmSource
-		engine: "powermanagement"
-		connectedSources: sources
-		onSourceAdded: {
-			// console.log('onSourceAdded', source)
-			disconnectSource(source)
-			connectSource(source)
-		}
-		onSourceRemoved: {
-			disconnectSource(source)
-		}
 
-		function log() {
-			for (var i = 0; i < pmSource.sources.length; i++) {
-				var sourceName = pmSource.sources[i]
-				var source = pmSource.data[sourceName]
-				for (var key in source) {
-					console.log('pmSource.data["'+sourceName+'"]["'+key+'"] =', source[key])
-				}
-			}
-		}
-	}
+    Plasmoid.status: {
+        if (powermanagementDisabled) {
+            return PlasmaCore.Types.ActiveStatus
+        }
+
+        if (pmSource.data.Battery["Has Cumulative"]) {
+            if (pmSource.data.Battery.State !== "Charging" && pmSource.data.Battery.Percent <= 5) {
+                return PlasmaCore.Types.NeedsAttentionStatus
+            } else if (pmSource.data["Battery"]["State"] !== "FullyCharged") {
+                return PlasmaCore.Types.ActiveStatus
+            }
+        }
+
+        return PlasmaCore.Types.PassiveStatus
+    }
+
+     Plasmoid.toolTipMainText: {
+        if (batteries.count === 0) {
+            return i18n("No Batteries Available");
+        } else if (!pmSource.data["Battery"]["Has Cumulative"]) {
+            // Bug 362924: Distinguish between no batteries and no power supply batteries
+            // just show the generic applet title in the latter case
+            return i18n("Battery and Brightness")
+        } else if (pmSource.data["Battery"]["State"] === "FullyCharged") {
+            return i18n("Fully Charged");
+        } else if (pmSource.data["AC Adapter"] && pmSource.data["AC Adapter"]["Plugged in"]) {
+            var percent = pmSource.data.Battery.Percent
+            var state = pmSource.data.Battery.State
+            if (state === "Charging") {
+                return i18n("%1%. Charging", percent)
+            } else if (state === "NoCharge") {
+                return i18n("%1%. Plugged in, not Charging", percent)
+            } else {
+                return i18n("%1%. Plugged in", percent)
+            }
+        } else {
+            if (remainingTime > 0) {
+                return i18nc("%1 is remaining time, %2 is percentage", "%1 Remaining (%2%)",
+                             KCoreAddons.Format.formatDuration(remainingTime, KCoreAddons.FormatTypes.HideSeconds),
+                             pmSource.data["Battery"]["Percent"])
+            } else {
+                return i18n("%1% Battery Remaining", pmSource.data["Battery"]["Percent"]);
+            }
+        }
+    }
+
+    Plasmoid.toolTipSubText: powermanagementDisabled ? i18n("Power management is disabled") : ""
+
+    property bool disableBrightnessUpdate: true
+    property int screenBrightness
+    readonly property int maximumScreenBrightness: pmSource.data["PowerDevil"] ? pmSource.data["PowerDevil"]["Maximum Screen Brightness"] || 0 : 0
+
+    property int keyboardBrightness
+    readonly property int maximumKeyboardBrightness: pmSource.data["PowerDevil"] ? pmSource.data["PowerDevil"]["Maximum Keyboard Brightness"] || 0 : 0
+
+    readonly property int remainingTime: Number(pmSource.data["Battery"]["Remaining msec"])
+
+    property bool powermanagementDisabled: false
+
+    property var inhibitions: []
+
+    readonly property var kcms: ["powerdevilprofilesconfig.desktop",
+                                 "powerdevilactivitiesconfig.desktop",
+                                 "powerdevilglobalconfig.desktop"]
+
+    readonly property bool kcmsAuthorized: KCMShell.authorize(batterywidget.kcms).length > 0
+
+    onScreenBrightnessChanged: {
+        if (disableBrightnessUpdate) {
+            return;
+        }
+        var service = pmSource.serviceForSource("PowerDevil");
+        var operation = service.operationDescription("setBrightness");
+        operation.brightness = screenBrightness;
+        // show OSD only when the plasmoid isn't expanded since the moving slider is feedback enough
+        operation.silent = plasmoid.expanded
+        service.startOperationCall(operation);
+    }
+
+    onKeyboardBrightnessChanged: {
+        if (disableBrightnessUpdate) {
+            return;
+        }
+        var service = pmSource.serviceForSource("PowerDevil");
+        var operation = service.operationDescription("setKeyboardBrightness");
+        operation.brightness = keyboardBrightness;
+        operation.silent = plasmoid.expanded
+        service.startOperationCall(operation);
+    }
+
+    function action_powerdevilkcm() {
+        KCMShell.open(batterywidget.kcms);
+    }
+
+    Component.onCompleted: {
+        Logic.updateBrightness(batterywidget, pmSource);
+        Logic.updateInhibitions(batterywidget, pmSource)
+
+        if (batterywidget.kcmsAuthorized) {
+            plasmoid.setAction("powerdevilkcm", i18n("&Configure Power Saving..."), "preferences-system-power-management");
+        }
+    }
+
+    property QtObject batteries: PlasmaCore.SortFilterModel {
+        id: batteries
+        filterRole: "Is Power Supply"
+        sortOrder: Qt.DescendingOrder
+        sourceModel: PlasmaCore.SortFilterModel {
+            sortRole: "Pretty Name"
+            sortOrder: Qt.AscendingOrder
+            sortCaseSensitivity: Qt.CaseInsensitive
+            sourceModel: PlasmaCore.DataModel {
+                dataSource: pmSource
+                sourceFilter: "Battery[0-9]+"
+            }
+        }
+    }
+
+	  // PlasmaCore.DataSource {
+    property QtObject pmSource: PlasmaCore.DataSource {
+		    id: pmSource
+		    engine: "powermanagement"
+		    connectedSources: sources
+		    onSourceAdded: {
+			      // console.log('onSourceAdded', source)
+			      disconnectSource(source)
+			      connectSource(source)
+		    }
+		    onSourceRemoved: {
+			      disconnectSource(source)
+		    }
+
+        onDataChanged: {
+            Logic.updateBrightness(batterywidget, pmSource)
+            Logic.updateInhibitions(batterywidget, pmSource)
+        }
+
+	  }
+
 
 	function getData(sourceName, key, def) {
 		var source = pmSource.data[sourceName]
@@ -50,101 +170,168 @@ Item {
 		}
 	}
 
-	property string currentBatteryName: 'Battery'
-	property string currentBatteryState: getData(currentBatteryName, 'State', false)
-	property int currentBatteryPercent: getData(currentBatteryName, 'Percent', 100)
-	property bool currentBatteryLowPower: currentBatteryPercent <= config.lowBatteryPercent
-	property color currentTextColor: {
-		if (currentBatteryLowPower) {
-			return config.lowBatteryColor
-		} else {
-			return config.normalColor
-		}
-	}
+	  property string currentBatteryName: 'Battery'
+	  property string currentBatteryState: getData(currentBatteryName, 'State', false)
+	  property int currentBatteryPercent: getData(currentBatteryName, 'Percent', 100)
+	  property bool currentBatteryLowPower: currentBatteryPercent <= config.lowBatteryPercent
+	  property color currentTextColor: {
+		    if (currentBatteryLowPower) {
+			      return config.lowBatteryColor
+		    } else {
+			      return config.normalColor
+		    }
+	  }
 
-	Plasmoid.compactRepresentation: Item {
-		id: panelItem
 
-		Layout.minimumWidth: gridLayout.implicitWidth
-		Layout.preferredWidth: gridLayout.implicitWidth
+	  Plasmoid.compactRepresentation: Item {
+		    id: panelItem
 
-		Layout.minimumHeight: gridLayout.implicitHeight
-		Layout.preferredHeight: gridLayout.implicitHeight
+        MouseArea {
+            id: desktopMouseArea
+            anchors.fill: parent
 
-		// property int textHeight: Math.max(6, Math.min(panelItem.height, 16 * units.devicePixelRatio))
-		property int textHeight: 12 * units.devicePixelRatio
-		// onTextHeightChanged: console.log('textHeight', textHeight)
+            onClicked:
+            {
+                plasmoid.expanded = !plasmoid.expanded
+            }
+        }
 
-		GridLayout {
-			id: gridLayout
-			anchors.fill: parent
+		    Layout.minimumWidth: gridLayout.implicitWidth
+		    Layout.preferredWidth: gridLayout.implicitWidth
 
-			// The rect around the Text items in the vertical layout should provide 2 pixels above
-			// and below. Adding extra space will make the space between the percentage and time left
-			// labels look bigger than the space between the icon and the percentage.
-			// So for vertical layouts, we'll add the spacing to just the icon.
-			property int spacing: 4 * units.devicePixelRatio
-			columnSpacing: spacing
-			rowSpacing: 0
+		    Layout.minimumHeight: gridLayout.implicitHeight
+		    Layout.preferredHeight: gridLayout.implicitHeight
 
-			PlasmaComponent.Label {
-				id: percentTextLeft
-				visible: plasmoid.configuration.showPercentage && !!plasmoid.configuration.alignLeft
-				anchors.right: batteryIconContainer.left
-				anchors.rightMargin: config.padding
-				text: {
-					if (currentBatteryPercent > 0) {
-						return '' + currentBatteryPercent + '%'
-					} else {
-						return '100%';
-					}
-				}
-				font.pixelSize: config.fontSize
-				fontSizeMode: Text.Fit
-				horizontalAlignment: Text.AlignHCenter
-				verticalAlignment: Text.AlignVCenter
-				color: currentTextColor
-			}
+		    // property int textHeight: Math.max(6, Math.min(panelItem.height, 16 * units.devicePixelRatio))
+		    property int textHeight: 12 * units.devicePixelRatio
+		    // onTextHeightChanged: console.log('textHeight', textHeight)
 
-			Item {
-				id: batteryIconContainer
-				visible: plasmoid.configuration.showBatteryIcon
-				width: config.iconWidth * units.devicePixelRatio
-				height: config.iconHeight * units.devicePixelRatio
-				anchors.verticalCenter: parent.verticalCenter
+		    GridLayout {
+			      id: gridLayout
+			      anchors.fill: parent
 
-				MacBatteryIcon {
-					id: batteryIcon
-					width: Math.min(parent.width, config.iconWidth * units.devicePixelRatio)
-					height: Math.min(parent.height, config.iconHeight * units.devicePixelRatio)
-					anchors.centerIn: parent
-					charging: currentBatteryState == "Charging"
-					charge: currentBatteryPercent
-					normalColor: config.normalColor
-					chargingColor: config.chargingColor
-					lowBatteryColor: config.lowBatteryColor
-					lowBatteryPercent: plasmoid.configuration.lowBatteryPercent
-				}
-			}
+			      // The rect around the Text items in the vertical layout should provide 2 pixels above
+			      // and below. Adding extra space will make the space between the percentage and time left
+			      // labels look bigger than the space between the icon and the percentage.
+			      // So for vertical layouts, we'll add the spacing to just the icon.
+			      property int spacing: 4 * units.devicePixelRatio
+			      columnSpacing: spacing
+			      rowSpacing: 0
 
-			PlasmaComponent.Label {
-				id: percentTextRight
-				visible: plasmoid.configuration.showPercentage && !plasmoid.configuration.alignLeft
-				anchors.left: batteryIconContainer.right
-				anchors.leftMargin: config.padding
-				text: {
-					if (currentBatteryPercent > 0) {
-						return '' + currentBatteryPercent + '%'
-					} else {
-						return '100%';
-					}
-				}
-				font.pixelSize: config.fontSize
-				fontSizeMode: Text.Fit
-				horizontalAlignment: Text.AlignHCenter
-				verticalAlignment: Text.AlignVCenter
-				color: currentTextColor
-			}
-		}
-	}
+			      PlasmaComponent.Label {
+				        id: percentTextLeft
+				        visible: plasmoid.configuration.showPercentage && !!plasmoid.configuration.alignLeft
+				        anchors.right: batteryIconContainer.left
+				        anchors.rightMargin: config.padding
+				        text: {
+					          if (currentBatteryPercent > 0) {
+						            return '' + currentBatteryPercent + '%'
+					          } else {
+						            return '100%';
+					          }
+				        }
+				        font.pixelSize: config.fontSize
+				        fontSizeMode: Text.Fit
+				        horizontalAlignment: Text.AlignHCenter
+				        verticalAlignment: Text.AlignVCenter
+				        color: currentTextColor
+			      }
+
+			      Item {
+				        id: batteryIconContainer
+				        visible: plasmoid.configuration.showBatteryIcon
+				        width: config.iconWidth * units.devicePixelRatio
+				        height: config.iconHeight * units.devicePixelRatio
+				        anchors.verticalCenter: parent.verticalCenter
+
+				        MacBatteryIcon {
+					          id: batteryIcon
+					          width: Math.min(parent.width, config.iconWidth * units.devicePixelRatio)
+					          height: Math.min(parent.height, config.iconHeight * units.devicePixelRatio)
+					          anchors.centerIn: parent
+					          charging: currentBatteryState == "Charging"
+					          charge: currentBatteryPercent
+					          normalColor: config.normalColor
+					          chargingColor: config.chargingColor
+					          lowBatteryColor: config.lowBatteryColor
+					          lowBatteryPercent: plasmoid.configuration.lowBatteryPercent
+				        }
+			      }
+
+			      PlasmaComponent.Label {
+				        id: percentTextRight
+				        visible: plasmoid.configuration.showPercentage && !plasmoid.configuration.alignLeft
+				        anchors.left: batteryIconContainer.right
+				        anchors.leftMargin: config.padding
+				        text: {
+					          if (currentBatteryPercent > 0) {
+						            return '' + currentBatteryPercent + '%'
+					          } else {
+						            return '100%';
+					          }
+				        }
+				        font.pixelSize: config.fontSize
+				        fontSizeMode: Text.Fit
+				        horizontalAlignment: Text.AlignHCenter
+				        verticalAlignment: Text.AlignVCenter
+				        color: currentTextColor
+			      }
+		    }
+	  }
+
+    Plasmoid.fullRepresentation: PopupDialog {
+        id: dialogItem
+        Layout.minimumWidth: units.iconSizes.medium * 9
+        Layout.minimumHeight: units.gridUnit * 15
+        // TODO Probably needs a sensible preferredHeight too
+
+        model: plasmoid.expanded ? batteries : null
+        anchors.fill: parent
+        focus: true
+
+        isBrightnessAvailable: pmSource.data["PowerDevil"] && pmSource.data["PowerDevil"]["Screen Brightness Available"] ? true : false
+        isKeyboardBrightnessAvailable: pmSource.data["PowerDevil"] && pmSource.data["PowerDevil"]["Keyboard Brightness Available"] ? true : false
+
+        pluggedIn: pmSource.data["AC Adapter"] != undefined && pmSource.data["AC Adapter"]["Plugged in"]
+
+        property int cookie1: -1
+        property int cookie2: -1
+        onPowermanagementChanged: {
+            var service = pmSource.serviceForSource("PowerDevil");
+            if (checked) {
+                var op1 = service.operationDescription("stopSuppressingSleep");
+                op1.cookie = cookie1;
+                var op2 = service.operationDescription("stopSuppressingScreenPowerManagement");
+                op2.cookie = cookie2;
+
+                var job1 = service.startOperationCall(op1);
+                job1.finished.connect(function(job) {
+                    cookie1 = -1;
+                });
+
+                var job2 = service.startOperationCall(op2);
+                job2.finished.connect(function(job) {
+                    cookie2 = -1;
+                });
+            } else {
+                var reason = i18n("The battery applet has enabled system-wide inhibition");
+                var op1 = service.operationDescription("beginSuppressingSleep");
+                op1.reason = reason;
+                var op2 = service.operationDescription("beginSuppressingScreenPowerManagement");
+                op2.reason = reason;
+
+                var job1 = service.startOperationCall(op1);
+                job1.finished.connect(function(job) {
+                    cookie1 = job.result;
+                });
+
+                var job2 = service.startOperationCall(op2);
+                job2.finished.connect(function(job) {
+                    cookie2 = job.result;
+                });
+            }
+
+            batterywidget.powermanagementDisabled = !checked
+        }
+    }
 }


### PR DESCRIPTION
As the title says, I added the code from the standard Plasma battery to be able to control the screen brightness and power management in the plasmoid full representation (which is invoked with a click). Also, the tooltip now displays  the battery state as opposed to the default plasmoid title.