### PR TITLE
Fix broken calls to Powerdevil KCM modules

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -77,9 +77,9 @@ Item {
 
     property var inhibitions: []
 
-    readonly property var kcms: ["powerdevilprofilesconfig.desktop",
-                                 "powerdevilactivitiesconfig.desktop",
-                                 "powerdevilglobalconfig.desktop"]
+    readonly property var kcms: ["powerdevilprofilesconfig",
+                                 "powerdevilactivitiesconfig",
+                                 "powerdevilglobalconfig"]
 
     readonly property bool kcmsAuthorized: KCMShell.authorize(batterywidget.kcms).length > 0
 


### PR DESCRIPTION
Fix #5 .

Recent KDE Plasma versions could not locate modules `powerdevilprofilesconfig.desktop`, `powerdevilactivitiesconfig.desktop` and `powerdevilglobalconfig.desktop`, causing a "shared library not found" error when trying to configure power saving.

Remove `.desktop` from module names and KCMShell will find those modules successfully.