### PR TITLE
fix: apply `lowBatteryColor` correctly

### DIFF
--- a/contents/ui/MacBatteryIcon.qml
+++ b/contents/ui/MacBatteryIcon.qml
@@ -30,7 +30,7 @@ Item {
 				color: {
 					if (charging) {
 						return chargingColor
-					} else if (charge < lowBatteryPercent) {
+					} else if (charge <= lowBatteryPercent) {
 						return lowBatteryColor
 					} else {
 						return normalColor


### PR DESCRIPTION
apply `lowBatteryColor` when charge is *equal or below*.

This is desired behavior. On mobile, when battery hits exactly 20% is already considered as low battery and color is changed.So when low battery is specified like 20% it is expected to turn red at exactly this percentage or lower